### PR TITLE
Aleatoric uncertainty

### DIFF
--- a/her2bdl/data/generator.py
+++ b/her2bdl/data/generator.py
@@ -346,13 +346,15 @@ class GridPatchGenerator(keras.utils.Sequence):
         batch_rows = self.dataset.iloc[list_indexes]
         batch_patches = np.empty((len(list_indexes), *self.patch_size, 3), dtype=np.float64)
         batch_scores  = np.empty((len(list_indexes), len(TARGET_LABELS)))
-        batch_v_flips = self.vertical_flips[list_indexes]
-        batch_h_flips = self.horizational_flips[list_indexes]
+        # TODO: fix index out of range
+        #batch_v_flips = self.vertical_flips[list_indexes]
+        #batch_h_flips = self.horizational_flips[list_indexes]
         for i, (_, row) in enumerate(batch_rows.iterrows()):
             case_no = int(row["CaseNo"])
             score   = int(row[TARGET])
             patch = self.load_patch(case_no, int(row["row"]), int(row["col"]))
-            v_flip, h_flip = batch_v_flips[i], batch_h_flips[i]
+            #v_flip, h_flip = batch_v_flips[i], batch_h_flips[i]
+            v_flip, h_flip = self.vertical_flips[i], self.horizational_flips[i]
             batch_patches[i] = np.array(patch)[::v_flip,::h_flip,:3]
             batch_scores[i]  = TARGET_TO_ONEHOT[score]
         return batch_patches, batch_scores

--- a/her2bdl/models/layers.py
+++ b/her2bdl/models/layers.py
@@ -78,3 +78,8 @@ class Separate_HED_stains(keras.layers.Layer):
         x = tf.nn.conv2d(-tf.math.log(x)/self.log_adjust, self.kernel, 1, "VALID")
         x = (x - self.min_values)/(self.max_values - self.min_values) # range (0,1)
         return x
+
+    def get_config(self):
+        config = super(Separate_HED_stains, self).get_config()
+        config["ignore_eosin"] = self.ignore_eosin
+        return config

--- a/her2bdl/visualization/prediction.py
+++ b/her2bdl/visualization/prediction.py
@@ -105,7 +105,7 @@ def plot_sample(x, y_true=None, y_pred=None, labels=None, axis=None):
     axis.set_title(title, y=-0.3)
     return axis
 
-def display_uncertainty(x, y_pred, predictive_distribution, prediction_samples,
+def display_uncertainty(x, y_pred, predictive_distribution, prediction_samples=None,
                         model_name=None, labels=None, y_true=None, 
                         uncertainty=None, show=False, save_to=None):
     """
@@ -120,8 +120,8 @@ def display_uncertainty(x, y_pred, predictive_distribution, prediction_samples,
         Predicted label.
     predictive_distribution : `np.ndarray`
         Predicted distribution (n_classes)
-    prediction_samples : `np.ndarray`
-        Predicted samples (samples, n_classes)
+    prediction_samples : `np.ndarray` or `None`
+        Predicted samples (samples, n_classes). Ignore second row plot if is `None`.
     model_name : `str`
         Model name.
     labels : `list`
@@ -139,6 +139,13 @@ def display_uncertainty(x, y_pred, predictive_distribution, prediction_samples,
         `matplotlib.figure.Figure`.
     """
     # Create new Figure
+    if prediction_samples is None:
+        ax1_subplot = 121
+        ax2_subplot = 122
+    else:
+        ax1_subplot = 221
+        ax2_subplot = 222
+
     fig = plt.figure(figsize=(8, 6))
     ax1 = plt.subplot(221)
     plot_sample(x, y_true=y_true, y_pred=y_pred, labels=labels, axis=ax1)
@@ -152,8 +159,9 @@ def display_uncertainty(x, y_pred, predictive_distribution, prediction_samples,
         # place a text box in upper left in axes coords
         ax2.text(0.05, 0.95, textstr, transform=ax2.transAxes, fontsize=10, 
                 verticalalignment='top', bbox=props)
-    ax3 = plt.subplot(212)
-    plot_forward_pass_samples(prediction_samples, y_true=y_true, labels=labels, axis=ax3)
+    if prediction_samples is not None:
+        ax3 = plt.subplot(212)
+        plot_forward_pass_samples(prediction_samples, y_true=y_true, labels=labels, axis=ax3)
     # Style
     title = f"Uncertainty\n{model_name}" if model_name is not None else "Uncertainty"
     plt.suptitle(title, fontsize=16)

--- a/todo.md
+++ b/todo.md
@@ -25,10 +25,11 @@
 # Milestone 5
 - [x] HPC Training (Binary tests)
 - [x] Load WSI images
-- [ ] Train EfficientNets B0-B7 (wsi)
+- [x] Train EfficientNets B0-B7 (wsi)
 - [ ] Aggregation
 
 # Milestone 6
+- [x] Model Aleatoric
 - [ ] Evaluation
 - [ ] Model Consumption
 

--- a/train/experiments/config/baseline_aleatoric/hedconv_c77_d02.yaml
+++ b/train/experiments/config/baseline_aleatoric/hedconv_c77_d02.yaml
@@ -1,0 +1,170 @@
+# Experiment information
+experiment:
+  # Custom indentifier name for the experiment.
+  # Experiment
+  name: HEDConvClassifier-McDropout
+  notes: HEDConvClassifier with MC-Dropout for Her2 Classification using WSI-MCPatchGenerator.
+  tags:
+    - hedconv
+    - hed
+    - C77
+    - mcdropout
+    - dropout_rate=0.2
+    - her2
+    - MCPatchGenerator
+    - training
+  # Experiments folder: Contains multiples experiments
+  experiments_folder: D:/sebas/Projects/her2bdl/train/experiments/runs
+  #experiments_folder: /data/atlas/dbetalhc/cta-test/gerumo/src/her2bdl/train/experiments/runs
+  # (Optional, default=null) numeric identfier for the experiment. If `null`, will be randomly picked.
+  run_id: null
+  # (Optional, default=null) Random seed, if it`s null, uses a random seed.
+  seed: 1234
+
+# Model architecture
+model:
+  # Model task: [classification|regression]
+  task: classification
+  # Model Class implemented in her2bdl.models
+  architecture: HEDConvClassifierMCDropout
+  # (Optional, default=null) Models pretrained weights path. If it is null, use random weight initialization.
+  weights: C:/Users/sebas/Desktop/her2bdl-files/model-best-02.h5
+  # Model architecture hyperparameters
+  hyperparameters: 
+    ignore_eosin: false
+    mc_dropout_rate: 0.2
+    encoder_kernel_sizes:
+      - 3
+      - 5
+      - 3
+    conv_activation: swish
+    classifier_dense_layers: 
+      - 128
+      - 128
+    dense_activation: swish
+  # Model uncertainty hyperparameters
+  # TODO: change name uncertainty  to epistemic
+  uncertainty:
+    sample_size: 200
+    mc_dropout_batch_size: 8
+    multual_information: true
+    variation_ratio: true
+    predictive_entropy: true
+
+# Aggregation methods
+aggregation: 
+  # Method Class
+  method: null
+  # Mathod parameters
+  parameters: null
+
+# Datasets and preprocessing
+data:
+  # Source
+  source:
+    type: wsi
+    # Source type parameters
+    parameters:
+      train_generator:
+        generator: 'MCPatchGenerator'
+        generator_parameters:
+          dataset: 'D:/sebas/Projects/her2bdl/train/datasets/debug.csv'
+          #dataset: '/data/atlas/dbetalhc/cta-test/gerumo/src/her2bdl/train/datasets/split/training.csv'
+          patch_level: 3
+          samples_per_tissue: 200
+          patch_vertical_flip: true
+          patch_horizontal_flip: true
+          shuffle: true
+      validation_generator:
+        generator: 'GridPatchGenerator'
+        generator_parameters:
+          dataset: 'D:/sebas/Projects/her2bdl/train/datasets/debug.csv'
+          #dataset: '/data/atlas/dbetalhc/cta-test/gerumo/src/her2bdl/train/datasets/split/validation.csv'
+          patch_level: 3
+          patch_vertical_flip: false
+          patch_horizontal_flip: false
+          shuffle: true
+      test_generator:
+        generator: 'GridPatchGenerator'
+        generator_parameters:
+          dataset: 'D:/sebas/Projects/her2bdl/train/datasets/test.csv'
+          #dataset: '/data/atlas/dbetalhc/cta-test/gerumo/src/her2bdl/train/datasets/test.csv'
+          patch_level: 3
+          patch_vertical_flip: false
+          patch_horizontal_flip: false
+          shuffle: true
+  # Input
+  img_height: 300
+  img_width: 300
+  img_channels: 3
+  preprocessing:
+    rescale: null
+    aggregate_dataset_parameters: null
+  # Target
+  num_classes: 4
+  label_mode: categorical  # Depends on task and model architecture
+  labels: 
+    - '0'
+    - '1+'
+    - '2+'
+    - '3+'
+
+# Training model hyperparameters
+training:
+  # Training epochs
+  epochs: 75
+  # (Optional, default=16) Depends on CPU-GPU available memory.
+  batch_size: 32
+  # (Optional, default=0.2) Train and validation split.
+  validation_split: null
+  # Models loss function
+  loss:
+    function: CategoricalCrossentropy
+    parameters: null
+  # (Optional, default=sgd(lr=1e-4)) Training optimizer
+  optimizer:
+    name: sgd
+    learning_rate: 1e-4
+    parameters: null
+  # Training callbacks
+  callbacks:
+    # Connect to weight and bias *Requiere plugins and env variable.* 
+    enable_wandb: true
+    # Early stop, use null to disable. 
+    earlystop: 
+      patience: 6
+      monitor: val_loss
+    # Experiments results while training
+    experiment_tracker:
+      # Save model architecture summary
+      #log_model_summary: true
+      # Save datasets info: source, sizes, etc. 
+      #log_dataset_description: true
+      # Plots and logs
+      #log_training_loss: true
+      log_predictions: true
+      log_uncertainty: true
+      log_confusion_matrix: true
+      log_metrics: true
+      log_roc_curve: true
+    # Save checkpoints: saved at experiments_folder/experiment/checkpoints
+    checkpoints:
+      # saved weights format
+      format: "weights.{epoch:03d}-{val_loss:.4f}.h5"
+      save_best_only: true
+      save_weights_only: true
+      monitor: val_loss
+# Evaluation metrics
+evaluate:
+  metrics: [accuracy]
+# Predict 
+predict:
+  save_aggregation: false
+  save_predictions: true
+  save_uncertainty: false
+# Plugin setups
+plugins:
+  wandb:
+    project: Her2BDL
+    # Use environment variable name (recommended) or API KEY.
+    apikey: D:/sebas/Projects/her2bdl/.wandb_secret

--- a/train/experiments/config/baseline_aleatoric/hedconv_c77_d05.yaml
+++ b/train/experiments/config/baseline_aleatoric/hedconv_c77_d05.yaml
@@ -1,0 +1,169 @@
+# Experiment information
+experiment:
+  # Custom indentifier name for the experiment.
+  # Experiment
+  name: HEDConvClassifier-McDropout
+  notes: HEDConvClassifier with MC-Dropout for Her2 Classification using WSI-MCPatchGenerator.
+  tags:
+    - hedconv
+    - hed
+    - C77
+    - mcdropout
+    - dropout_rate=0.5
+    - her2
+    - MCPatchGenerator
+    - training
+  # Experiments folder: Contains multiples experiments
+  #experiments_folder: D:/sebas/Projects/her2bdl/train/experiments/runs
+  experiments_folder: /data/atlas/dbetalhc/cta-test/gerumo/src/her2bdl/train/experiments/runs
+  # (Optional, default=null) numeric identfier for the experiment. If `null`, will be randomly picked.
+  run_id: null
+  # (Optional, default=null) Random seed, if it`s null, uses a random seed.
+  seed: 1234
+
+# Model architecture
+model:
+  # Model task: [classification|regression]
+  task: classification
+  # Model Class implemented in her2bdl.models
+  architecture: HEDConvClassifierMCDropout
+  # (Optional, default=null) Models pretrained weights path. If it is null, use random weight initialization.
+  weights: null
+  # Model architecture hyperparameters
+  hyperparameters: 
+    ignore_eosin: false
+    mc_dropout_rate: 0.5
+    encoder_kernel_sizes:
+      - 3
+      - 5
+      - 3
+    conv_activation: swish
+    classifier_dense_layers: 
+      - 128
+      - 128
+    dense_activation: swish
+  # Model uncertainty hyperparameters
+  uncertainty:
+    sample_size: 200
+    mc_dropout_batch_size: 8
+    multual_information: true
+    variation_ratio: true
+    predictive_entropy: true
+
+# Aggregation methods
+aggregation: 
+  # Method Class
+  method: null
+  # Mathod parameters
+  parameters: null
+
+# Datasets and preprocessing
+data:
+  # Source
+  source:
+    type: wsi
+    # Source type parameters
+    parameters:
+      train_generator:
+        generator: 'MCPatchGenerator'
+        generator_parameters:
+          #dataset: 'D:/sebas/Projects/her2bdl/train/datasets/train.csv'
+          dataset: '/data/atlas/dbetalhc/cta-test/gerumo/src/her2bdl/train/datasets/split/training.csv'
+          patch_level: 3
+          samples_per_tissue: 200
+          patch_vertical_flip: true
+          patch_horizontal_flip: true
+          shuffle: true
+      validation_generator:
+        generator: 'GridPatchGenerator'
+        generator_parameters:
+          #dataset: 'D:/sebas/Projects/her2bdl/train/datasets/validation.csv'
+          dataset: '/data/atlas/dbetalhc/cta-test/gerumo/src/her2bdl/train/datasets/split/validation.csv'
+          patch_level: 3
+          patch_vertical_flip: false
+          patch_horizontal_flip: false
+          shuffle: true
+      test_generator:
+        generator: 'GridPatchGenerator'
+        generator_parameters:
+          #dataset: 'D:/sebas/Projects/her2bdl/train/datasets/test.csv'
+          dataset: '/data/atlas/dbetalhc/cta-test/gerumo/src/her2bdl/train/datasets/test.csv'
+          patch_level: 3
+          patch_vertical_flip: false
+          patch_horizontal_flip: false
+          shuffle: true
+  # Input
+  img_height: 300
+  img_width: 300
+  img_channels: 3
+  preprocessing:
+    rescale: null
+    aggregate_dataset_parameters: null
+  # Target
+  num_classes: 4
+  label_mode: categorical  # Depends on task and model architecture
+  labels: 
+    - '0'
+    - '1+'
+    - '2+'
+    - '3+'
+
+# Training model hyperparameters
+training:
+  # Training epochs
+  epochs: 75
+  # (Optional, default=16) Depends on CPU-GPU available memory.
+  batch_size: 32
+  # (Optional, default=0.2) Train and validation split.
+  validation_split: null
+  # Models loss function
+  loss:
+    function: CategoricalCrossentropy
+    parameters: null
+  # (Optional, default=sgd(lr=1e-4)) Training optimizer
+  optimizer:
+    name: sgd
+    learning_rate: 1e-4
+    parameters: null
+  # Training callbacks
+  callbacks:
+    # Connect to weight and bias *Requiere plugins and env variable.* 
+    enable_wandb: true
+    # Early stop, use null to disable. 
+    earlystop: 
+      patience: 6
+      monitor: val_loss
+    # Experiments results while training
+    experiment_tracker:
+      # Save model architecture summary
+      log_model_summary: true
+      # Save datasets info: source, sizes, etc. 
+      log_dataset_description: true
+      # Plots and logs
+      log_training_loss: true
+      log_predictions: true
+      log_uncertainty: true
+      log_confusion_matrix: true
+      log_metrics: true
+      log_roc_curve: true
+    # Save checkpoints: saved at experiments_folder/experiment/checkpoints
+    checkpoints:
+      # saved weights format
+      format: "weights.{epoch:03d}-{val_loss:.4f}.h5"
+      save_best_only: true
+      save_weights_only: true
+      monitor: val_loss
+# Evaluation metrics
+evaluate:
+  metrics: [accuracy]
+# Predict 
+predict:
+  save_aggregation: false
+  save_predictions: true
+  save_uncertainty: false
+# Plugin setups
+plugins:
+  wandb:
+    project: Her2BDL
+    # Use environment variable name (recommended) or API KEY.
+    apikey: WANDB_API_KEY

--- a/train/experiments/config/baseline_aleatoric/hedconv_c77_d08.yaml
+++ b/train/experiments/config/baseline_aleatoric/hedconv_c77_d08.yaml
@@ -1,0 +1,169 @@
+# Experiment information
+experiment:
+  # Custom indentifier name for the experiment.
+  # Experiment
+  name: HEDConvClassifier-McDropout
+  notes: HEDConvClassifier with MC-Dropout for Her2 Classification using WSI-MCPatchGenerator.
+  tags:
+    - hedconv
+    - hed
+    - C77
+    - mcdropout
+    - dropout_rate=0.8
+    - her2
+    - MCPatchGenerator
+    - training
+  # Experiments folder: Contains multiples experiments
+  #experiments_folder: D:/sebas/Projects/her2bdl/train/experiments/runs
+  experiments_folder: /data/atlas/dbetalhc/cta-test/gerumo/src/her2bdl/train/experiments/runs
+  # (Optional, default=null) numeric identfier for the experiment. If `null`, will be randomly picked.
+  run_id: null
+  # (Optional, default=null) Random seed, if it`s null, uses a random seed.
+  seed: 1234
+
+# Model architecture
+model:
+  # Model task: [classification|regression]
+  task: classification
+  # Model Class implemented in her2bdl.models
+  architecture: HEDConvClassifierMCDropout
+  # (Optional, default=null) Models pretrained weights path. If it is null, use random weight initialization.
+  weights: null
+  # Model architecture hyperparameters
+  hyperparameters: 
+    ignore_eosin: false
+    mc_dropout_rate: 0.8
+    encoder_kernel_sizes:
+      - 3
+      - 5
+      - 3
+    conv_activation: swish
+    classifier_dense_layers: 
+      - 128
+      - 128
+    dense_activation: swish
+  # Model uncertainty hyperparameters
+  uncertainty:
+    sample_size: 200
+    mc_dropout_batch_size: 8
+    multual_information: true
+    variation_ratio: true
+    predictive_entropy: true
+
+# Aggregation methods
+aggregation: 
+  # Method Class
+  method: null
+  # Mathod parameters
+  parameters: null
+
+# Datasets and preprocessing
+data:
+  # Source
+  source:
+    type: wsi
+    # Source type parameters
+    parameters:
+      train_generator:
+        generator: 'MCPatchGenerator'
+        generator_parameters:
+          #dataset: 'D:/sebas/Projects/her2bdl/train/datasets/train.csv'
+          dataset: '/data/atlas/dbetalhc/cta-test/gerumo/src/her2bdl/train/datasets/split/training.csv'
+          patch_level: 3
+          samples_per_tissue: 200
+          patch_vertical_flip: true
+          patch_horizontal_flip: true
+          shuffle: true
+      validation_generator:
+        generator: 'GridPatchGenerator'
+        generator_parameters:
+          #dataset: 'D:/sebas/Projects/her2bdl/train/datasets/validation.csv'
+          dataset: '/data/atlas/dbetalhc/cta-test/gerumo/src/her2bdl/train/datasets/split/validation.csv'
+          patch_level: 3
+          patch_vertical_flip: false
+          patch_horizontal_flip: false
+          shuffle: true
+      test_generator:
+        generator: 'GridPatchGenerator'
+        generator_parameters:
+          #dataset: 'D:/sebas/Projects/her2bdl/train/datasets/test.csv'
+          dataset: '/data/atlas/dbetalhc/cta-test/gerumo/src/her2bdl/train/datasets/test.csv'
+          patch_level: 3
+          patch_vertical_flip: false
+          patch_horizontal_flip: false
+          shuffle: true
+  # Input
+  img_height: 300
+  img_width: 300
+  img_channels: 3
+  preprocessing:
+    rescale: null
+    aggregate_dataset_parameters: null
+  # Target
+  num_classes: 4
+  label_mode: categorical  # Depends on task and model architecture
+  labels: 
+    - '0'
+    - '1+'
+    - '2+'
+    - '3+'
+
+# Training model hyperparameters
+training:
+  # Training epochs
+  epochs: 75
+  # (Optional, default=16) Depends on CPU-GPU available memory.
+  batch_size: 32
+  # (Optional, default=0.2) Train and validation split.
+  validation_split: null
+  # Models loss function
+  loss:
+    function: CategoricalCrossentropy
+    parameters: null
+  # (Optional, default=sgd(lr=1e-4)) Training optimizer
+  optimizer:
+    name: sgd
+    learning_rate: 1e-4
+    parameters: null
+  # Training callbacks
+  callbacks:
+    # Connect to weight and bias *Requiere plugins and env variable.* 
+    enable_wandb: true
+    # Early stop, use null to disable. 
+    earlystop: 
+      patience: 6
+      monitor: val_loss
+    # Experiments results while training
+    experiment_tracker:
+      # Save model architecture summary
+      log_model_summary: true
+      # Save datasets info: source, sizes, etc. 
+      log_dataset_description: true
+      # Plots and logs
+      log_training_loss: true
+      log_predictions: true
+      log_uncertainty: true      
+      log_confusion_matrix: true
+      log_metrics: true
+      log_roc_curve: true
+    # Save checkpoints: saved at experiments_folder/experiment/checkpoints
+    checkpoints:
+      # saved weights format
+      format: "weights.{epoch:03d}-{val_loss:.4f}.h5"
+      save_best_only: true
+      save_weights_only: true
+      monitor: val_loss
+# Evaluation metrics
+evaluate:
+  metrics: [accuracy]
+# Predict 
+predict:
+  save_aggregation: false
+  save_predictions: true
+  save_uncertainty: false
+# Plugin setups
+plugins:
+  wandb:
+    project: Her2BDL
+    # Use environment variable name (recommended) or API KEY.
+    apikey: WANDB_API_KEY

--- a/train/train_aleatoric.py
+++ b/train/train_aleatoric.py
@@ -1,0 +1,139 @@
+import sys
+#FIX: this. re structuring the project
+sys.path.insert(1, '..')
+
+from her2bdl import *
+
+from pathlib import Path
+import logging
+import time
+import numpy as np
+
+
+def train_model(config, quiet=False, run_dir="."):
+
+    # Experiment paths and indentifiers
+    experiments_folder = config["experiment"]["experiments_folder"]
+    experiment_name    = config["experiment"]["name"]
+    experiment_folder  = Path(experiments_folder) / experiment_name
+    run_id             = config["experiment"]["run_id"]
+    
+    # Training parameters
+    epochs = config["training"]["epochs"]
+    batch_size  = config["training"]["batch_size"]    
+
+    # Dataset
+    data_configuration = config["data"]
+    generators, input_shape, num_classes, labels = setup_generators(
+        batch_size=batch_size, **data_configuration
+    )
+    train_, val_ = generators
+    (train_dataset, steps_per_epoch) = train_
+    (val_dataset, validation_steps)  = val_
+
+    # Model architecture
+    model_configuration = config["model"]
+    model = setup_model(input_shape, num_classes, **model_configuration)
+    aleatoric_model = model.get_aleatoric_model()
+
+    ## Loss
+    loss = aleatoric_model.build_aleatoric_loss()
+
+    ## Optimizer
+    optimizer_name = config["training"]["optimizer"]["name"]
+    optimizer_learning_rate = float(config["training"]["optimizer"]["learning_rate"]) # fix scientific notation parsed as str.
+    optimizer_parameters = config["training"]["optimizer"].get("parameters", {})
+    optimizer_parameters = optimizer_parameters or {}
+    optimizer = OPTIMIZERS[optimizer_name](
+        learning_rate=optimizer_learning_rate, 
+        **optimizer_parameters
+    )
+    ## Callbacks
+    enable_wandb = config["training"]["callbacks"]["enable_wandb"]
+    earlystop = config["training"]["callbacks"]["earlystop"]
+    experiment_tracker = config["training"]["callbacks"]["experiment_tracker"]
+    checkpoints = config["training"]["callbacks"]["checkpoints"]
+    callbacks = setup_callbacks(
+         validation_data=val_dataset, 
+         validation_steps=validation_steps,
+         model_name=experiment_name,
+         batch_size=batch_size,
+         enable_wandb=enable_wandb,
+         labels=labels,
+         earlystop=earlystop,
+         experiment_tracker=experiment_tracker,
+         checkpoints=checkpoints,
+         run_dir=run_dir,
+         uncertainty_type="aleatoric"
+    )
+    
+    # Train
+    aleatoric_model.compile(
+        optimizer=optimizer,
+        loss=loss
+    )
+    history = aleatoric_model.fit(train_dataset, 
+        verbose = 2 if quiet else 1,
+        steps_per_epoch=steps_per_epoch,
+        validation_data=val_dataset, 
+        validation_steps=validation_steps,
+        epochs=epochs,
+        callbacks=callbacks
+    )
+    
+    # Return final model
+    return aleatoric_model
+
+if __name__ == "__main__":
+    import argparse
+    ap = argparse.ArgumentParser(description="Train aleatoric version of model.")
+    ap.add_argument("-c", "--config", type=str, required=True, 
+        help="Configuration file for model/experiment.")
+    ap.add_argument("--dryrun", action='store_true', 
+        help="Run locally. Upload your results to wandb servers afterwards.")
+    ap.add_argument("--quiet", action='store_true', 
+        help="Disable progress bar.") 
+    ap.add_argument("--disable_wandb", action='store_true', 
+        help="Disable WandB for locally testing without Weight&Bias Callbacks.")
+    ap.add_argument("--job", type=int, default=None, 
+        help="Disable WandB for locally testing without Weight&Bias Callbacks.")
+    ap.add_argument("--seed", type=int, default=None, 
+        help="Overwrite experiment`s seed.")
+    args = vars(ap.parse_args()) 
+
+    # Load experiment configuration
+    config_file = args["config"]
+    print(f"Loading config from: {config_file}")
+    experiment_config = load_config_file(config_file)
+
+    # Configure multiples runs
+    job = args["job"]
+    if job is not None:
+        model_name = experiment_config["experiment"]["name"]
+        job_sufix  = f"job {str(job).zfill(2)}"
+        experiment_config["experiment"]["name"]= f"{model_name} {job_sufix}"
+    # Overwrite seed
+    seed = args["seed"]
+    if seed is not None:
+        experiment_config["experiment"]["seed"]= seed
+    # Setup experiments and pluggins
+    if args["disable_wandb"]:
+        experiment_config["training"]["callbacks"]["enable_wandb"] = False
+        experiment_config["plugins"]["wandb"] = None
+    if args["dryrun"]:
+        WANDB_MODE_bck = os.environ.get("WANDB_MODE", None)
+        os.environ["WANDB_MODE"] = 'dryrun'
+    # Add Aleatoric modifications
+    experiment_config["experiment"]["tags"].append("aleatoric")
+
+    run_dir = setup_experiment(experiment_config, mode="training")
+    
+    # Verbosity
+    quiet = args["quiet"]
+
+    # Run training process
+    model = train_model(experiment_config, quiet=quiet, run_dir=run_dir)
+
+    # restore configuration
+    if args["dryrun"]:
+        os.environ["WANDB_MODE"] = WANDB_MODE_bck


### PR DESCRIPTION
The Monte-Carlo dropout model (`MCDropoutModel`) cannot model the aleatoric uncertainty. This PR adds the new model `AleatoricModel` and training script to measure aleatoric uncertainty for classification problems. It is achieved by implementing the method discussed in the Kendall & Ga paper: "What uncertainties do we need in Bayesian deep learning for computer vision?" [1]. 

`AleatoricModel` is architecture-independent but requires the submodel structure given by an `MCDropoutModel.` The model is defined by copying the layers from the encoder submodel; for the classifier model, the *mc_dropout* layers are ignored, the classifier head is replaced with a _logits_ and variance head. 

$$F(x) = f^w, (\sigma^w)^2$$

$f_i^w$ is a logit vector, and $(\sigma^w)^2$ is the predictive variance, the aleatoric uncertainty.

For training, the loss function is a modified version of a **Negative Log-Likelihood** with $T$ Monte-Carlo samples using the outputted model's variance:

$$\hat{x_t} =  f^w + \sigma^w\ \epsilon_t, \quad \epsilon_t \sim \mathcal{N}(0,\mathbb{1})$$

The logit vector is corrupted with noise from a vector sampled from a normal with mean $\vector{0}$ and covariance matrix $\mathbb{1}(\sigma^w)^{2}$.

$$\mathcal{L}_x = \log(\frac{1}{T}\sum_t\exp(\hat{x}_{t, c^*} - \log(\sum_{c^k} \exp(\hat{x}_{t, c^k})))$$

* [1] KENDALL, Alex; GAL, Yarin. What uncertainties do we need in Bayesian deep learning for computer vision?. arXiv preprint arXiv:1703.04977, 2017. [pdf](https://arxiv.org/pdf/1703.04977.pdf)